### PR TITLE
Add as_curl

### DIFF
--- a/lib/yt/http_request.rb
+++ b/lib/yt/http_request.rb
@@ -54,6 +54,18 @@ module Yt
       end
     end
 
+    # Returns the +cURL+ version of the request, useful to re-run the request
+    # in a shell terminal.
+    # @return [String] the +cURL+ version of the request.
+    def as_curl
+      'curl'.tap do |curl|
+        curl << " -X #{http_request.method}"
+        http_request.each_header{|k, v| curl << %Q{ -H "#{k}: #{v}"}}
+        curl << %Q{ -d '#{http_request.body}'} if http_request.body
+        curl << %Q{ "#{uri.to_s}"}
+      end
+    end
+
   private
 
     # @return [URI::HTTPS] the (memoized) URI of the request.

--- a/spec/http_request_spec.rb
+++ b/spec/http_request_spec.rb
@@ -33,3 +33,17 @@ describe 'Yt::HTTPRequest#run' do
     end
   end
 end
+
+describe 'Yt::HTTPRequest#as_curl' do
+  context 'given a request to a YouTube JSON API' do
+    path = '/discovery/v1/apis/youtube/v3/rest'
+    headers = {'User-Agent' => 'Yt::HTTPRequest'}
+    params = {verbose: 1}
+    request = Yt::HTTPRequest.new path: path, headers: headers, params: params
+    request_as_curl = 'curl -X GET -H "content-type: application/json" -H "user-agent: Yt::HTTPRequest" "https://www.googleapis.com/discovery/v1/apis/youtube/v3/rest?verbose=1"'
+
+    it 'returns a curl version of the request' do
+      expect(request.as_curl).to eq request_as_curl
+    end
+  end
+end


### PR DESCRIPTION
I borrowed `as_curl` method from 'yt' gem. and think it could be useful for debugging projects which use 'yt-core' gem. Thank you