### PR TITLE
Add a simple retry

### DIFF
--- a/lib/yt/http_request.rb
+++ b/lib/yt/http_request.rb
@@ -50,8 +50,10 @@ module Yt
           parse_response!
         end
       else
-        retry_run
+        raise Yt::HTTPError, error_message
       end
+    rescue Net::HTTPServerError
+      retry_run
     end
 
   private
@@ -59,7 +61,7 @@ module Yt
     # retry the run method in case of a random 500 error from YouTube API
     def retry_run
       if @retried
-        raise Yt::HTTPError, error_message
+        raise Yt::ConnectionError, error_message
       else
         @retried = true
         @response = nil

--- a/lib/yt/http_request.rb
+++ b/lib/yt/http_request.rb
@@ -50,11 +50,23 @@ module Yt
           parse_response!
         end
       else
-        raise Yt::HTTPError, error_message
+        retry_run
       end
     end
 
   private
+
+    # retry the run method in case of a random 500 error from YouTube API
+    def retry_run
+      if @retried
+        raise Yt::HTTPError, error_message
+      else
+        @retried = true
+        @response = nil
+        sleep 5
+        run
+      end
+    end
 
     # @return [URI::HTTPS] the (memoized) URI of the request.
     def uri

--- a/spec/http_request_spec.rb
+++ b/spec/http_request_spec.rb
@@ -32,4 +32,19 @@ describe 'Yt::HTTPRequest#run' do
       expect{request.run}.to raise_error Yt::ConnectionError
     end
   end
+
+  context 'given that YouTube API raises an error' do
+    context 'only once' do
+      path = '/discovery/v1/apis/youtube/v3/rest'
+      headers = {'User-Agent' => 'Yt::HTTPRequest'}
+      params = {verbose: 1}
+      let(:request) { Yt::HTTPRequest.new path: path, headers: headers, params: params }
+      let(:retry_response) { Net::HTTPSuccess.new '1.0', '200', 'OK' }
+      before { expect(Net::HTTP).to receive(:start).at_least(:once).and_return retry_response }
+      it 'returns the HTTP response with the JSON-parsed body' do
+        allow(retry_response).to receive(:body).and_return('{"fake": "body"}')
+        expect { request.run }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Handle the case when the YouTube API raises a backend 500 error randomly