### PR TITLE
Add ActiveSupport::Notifications instrumentation

### DIFF
--- a/lib/yt/http_request.rb
+++ b/lib/yt/http_request.rb
@@ -162,7 +162,7 @@ module Yt
       if defined?(ActiveSupport::Notifications)
         ActiveSupport::Notifications.instrument 'request.yt', data, &block
       else
-        yield data
+        block.call(data)
       end
     end
   end

--- a/spec/http_request_spec.rb
+++ b/spec/http_request_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe 'Yt::HTTPRequest#run' do
   context 'given a valid GET request to a YouTube JSON API' do
-    path = '/discovery/v1/apis/youtube/v3/rest'
-    headers = {'User-Agent' => 'Yt::HTTPRequest'}
-    params = {verbose: 1}
-    request = Yt::HTTPRequest.new path: path, headers: headers, params: params
+    let(:path) { '/discovery/v1/apis/youtube/v3/rest' }
+    let(:headers) { {'User-Agent' => 'Yt::HTTPRequest'} }
+    let(:params) { {verbose: 1} }
+    let(:request) { Yt::HTTPRequest.new path: path, headers: headers, params: params }
 
     it 'returns the HTTP response with the JSON-parsed body' do
       response = request.run


### PR DESCRIPTION
Adds support for instrumentation via ActiveSupport::Notifications. This
only happens when the module is loaded and defined. Otherwise
instrumetation no-ops.